### PR TITLE
Removed some tests for tagCount to improve speed

### DIFF
--- a/spec/part2.js
+++ b/spec/part2.js
@@ -8,10 +8,6 @@
       var htmlStrings = [
         '<p class="recursionTest"></p>',
         '<p class="otherClassName recursionTest"></p>',
-        '<p><p class="recursionTest"></p></p>',
-        '<p><p class="recursionTest"><p class="recursionTest"></p></p></p>',
-        '<p><p></p><p><p class="recursionTest"></p></p></p>',
-        '<p><p class="recursionTest"></p><p class="recursionTest"></p></p>',
         '<p><div class="somediv"><div class="innerdiv"><span class="recursionTest">yay</span></div></div></p>'
       ];
 


### PR DESCRIPTION
Removed some test cases for tagCount because it was a little expensive.  Removing these test cases makes the tests a little less expensive.