### PR TITLE
Changed 'sum' prompt to return 0 for empty array

### DIFF
--- a/spec/part1.js
+++ b/spec/part1.js
@@ -56,8 +56,8 @@
         expect(sum([3,0,-34,-7,18])).to.eql(-20);
       });
 
-      it('should return undefined for an empty array', function() {
-        expect(sum([])).to.eql(undefined);
+      it('should return 0 for empty array', function() {
+        expect(sum([])).to.eql(0);
       });
 
       it('should accept an array with a single integer', function() {


### PR DESCRIPTION
It seemed inconsistent for 'sum' to return undefined for an empty
array, so I modified the test to expect 0 to be returned when given
an empty array.  This is consistent with the test for 'arraySum'.