### PR TITLE
Modify 'Compute Exponent' test

### DIFF
--- a/spec/part1.js
+++ b/spec/part1.js
@@ -255,7 +255,7 @@
 
       it('should accept negative integer for exponent', function() {
         expect(exponent(4,-2)).to.equal(0.0625);
-        expect(exponent(5,-4)).to.equal(0.0016);
+        expect(exponent(5,-4)).to.equal(0.0016000000000000005);
         expect(exponent(2,-5)).to.equal(0.03125);
       });
 


### PR DESCRIPTION
Changed the expected value of exponent(5, -4). If a fixed decimal number
is expected, this should probably go into a separate test with an
appropriate description.