### PR TITLE
Correct a test message for Sum Below

### DIFF
--- a/spec/part1.js
+++ b/spec/part1.js
@@ -276,7 +276,7 @@
         expect(sumBelow(12)).to.equal(66);
       });
 
-      it('should return the sum of an array of negative integers', function() {
+      it('should return the sum of negative integers above given negative integer', function() {
         expect(sumBelow(-1)).to.equal(0);
         expect(sumBelow(-2)).to.equal(-1);
         expect(sumBelow(-6)).to.equal(-15);


### PR DESCRIPTION
Previously the message referenced an array when it should have only
referred to integers.